### PR TITLE
Feature/status check handler

### DIFF
--- a/apiStatusLib/README.md
+++ b/apiStatusLib/README.md
@@ -1,0 +1,59 @@
+# API Status Check
+
+## Setup
+
+```go
+import (
+  ...
+  apistatus "github.com/udistrital/utils_oas/apiStatusLib"
+)
+```
+
+## Usage in "basic APIs": `Init()`
+
+For basic MID APIs that, as example "only perfoms requests to another APIs"
+(Note that this can even be checked with an specific healthcheck)
+
+Usage Example:
+
+```go
+func main() {
+  ...
+  apistatus.Init()
+  beego.Run()
+}
+```
+
+## Accepting a handler function: `InitWithHandler(errorCheckHandler)`
+
+For another kind of APIs that would require a handler that performs the healthcheck.
+
+When specified (`errorCheckHandler != nil`) only will return `Status: Ok` when the `errorCheckHandler`
+returns `nil`. Otherwise, let it be `!= nil` or whenever the `errorCheckHandler` crashes (throwing a `panic()`)
+that will be indicated in the status
+
+Usage Example:
+
+```go
+// statusCheckHandler better to be in another file. Even inside another
+// package (folder) would also be fine. Keep in mind that this handler
+// function can be called many times as it would be being called on every GET "/"
+func statusCheckHandler() (checkError interface{}) {
+  ... // Perform healthchecks
+
+  // Once checked everything, return one of the following ones:
+  return nil // when everything is OK
+  return // (Same as above if checkError was left "pristine")
+  return ... // any interface{}: string, a map[string]interface{}, ...
+
+  // Alternatively/complementarily, if this healthcheck crashes and/or throws
+  // a panic, the panic() will be catched and shown
+  panic(...) // any interface{}: string, error, a map[string]interface{}, ...
+}
+
+func main() {
+  ...
+  apistatus.InitWithHandler(statusCheckHandler)
+  beego.Run()
+}
+```

--- a/apiStatusLib/apistatus.go
+++ b/apiStatusLib/apistatus.go
@@ -23,12 +23,17 @@ func formatErrorResponse(errorMsg interface{}) map[string]interface{} {
 // healthcheck, returns "nil" when everything is OK.
 func InitWithHandler(statusCheckHandler func() (statusCheckError interface{})) {
 
-	response := defaultStatusResponse
+	var responseError interface{}
 
 	// "catch"
 	defer func() {
 		if err := recover(); err != nil {
-			response = formatErrorResponse(err)
+			responseError = err
+		}
+
+		response := defaultStatusResponse
+		if responseError != nil {
+			formatErrorResponse(responseError)
 		}
 
 		// "finally"
@@ -40,7 +45,7 @@ func InitWithHandler(statusCheckHandler func() (statusCheckError interface{})) {
 	// "try"
 	if statusCheckHandler != nil {
 		if err := statusCheckHandler(); err != nil {
-			response = formatErrorResponse(err)
+			responseError = err
 		}
 	}
 }

--- a/apiStatusLib/apistatus.go
+++ b/apiStatusLib/apistatus.go
@@ -1,13 +1,13 @@
 package apistatus
 
-import(
+import (
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
 )
 
 func Init() {
-	beego.Any("/",func(ctx *context.Context){
-    response := map[string]interface{}{"Status": "Ok"} 
-	ctx.Output.JSON(response,true,true)
-})
+	beego.Any("/", func(ctx *context.Context) {
+		response := map[string]interface{}{"Status": "Ok"}
+		ctx.Output.JSON(response, true, true)
+	})
 }

--- a/apiStatusLib/apistatus.go
+++ b/apiStatusLib/apistatus.go
@@ -1,13 +1,50 @@
 package apistatus
 
 import (
+	"fmt"
+
 	"github.com/astaxie/beego"
 	"github.com/astaxie/beego/context"
 )
 
+func statusResponse(status string) map[string]interface{} {
+	return map[string]interface{}{
+		"Status": status,
+	}
+}
+
+var defaultStatusResponse map[string]interface{} = statusResponse("Ok")
+
+func formatErrorResponse(errorMsg interface{}) map[string]interface{} {
+	return statusResponse(fmt.Sprintf("ERROR: %v", errorMsg))
+}
+
+// InitWithHandler accepts a (handler) function that, once performs the
+// healthcheck, returns "nil" when everything is OK.
+func InitWithHandler(statusCheckHandler func() (statusCheckError interface{})) {
+
+	response := defaultStatusResponse
+
+	// "catch"
+	defer func() {
+		if err := recover(); err != nil {
+			response = formatErrorResponse(err)
+		}
+
+		// "finally"
+		beego.Any("/", func(ctx *context.Context) {
+			ctx.Output.JSON(response, true, true)
+		})
+	}()
+
+	// "try"
+	if statusCheckHandler != nil {
+		if err := statusCheckHandler(); err != nil {
+			response = formatErrorResponse(err)
+		}
+	}
+}
+
 func Init() {
-	beego.Any("/", func(ctx *context.Context) {
-		response := map[string]interface{}{"Status": "Ok"}
-		ctx.Output.JSON(response, true, true)
-	})
+	InitWithHandler(nil)
 }

--- a/apiStatusLib/apistatus_test.go
+++ b/apiStatusLib/apistatus_test.go
@@ -1,0 +1,55 @@
+// REFERENCIA PARA EL TESTEO:
+// https://golang.org/doc/tutorial/add-a-test
+
+package apistatus
+
+import (
+	"testing"
+	// "github.com/astaxie/beego"
+	// "github.com/astaxie/beego/context"
+)
+
+// TESTS DE EXITO
+
+func TestInitWithHandler(t *testing.T) {
+	sucessHandler := func() (err interface{}) {
+		return
+	}
+	InitWithHandler(sucessHandler)
+	// TODO: Simular llamado al controlador "/"
+	if true {
+		t.Fatalf("TEST POR IMPLEMENTAR - InitWithHandler no retornó {Status: Ok}")
+	}
+}
+
+func TestInit(t *testing.T) {
+	Init()
+	// TODO: Simular llamado al controlador "/"
+	if true {
+		t.Fatalf("TEST POR IMPLEMENTAR - Init no retornó {Status: Ok}")
+	}
+}
+
+// TESTS DE FALLOS
+
+func TestInitWithHandlerPanicFail(t *testing.T) {
+	failureHandlerWithPanic := func() (err interface{}) {
+		panic("ErrWithPanic")
+	}
+	InitWithHandler(failureHandlerWithPanic)
+	// TODO: Simular llamado al controlador "/"
+	if true {
+		t.Fatalf("TEST POR IMPLEMENTAR - InitWithHandler no retornó {Status: ERROR: ...} ante panic()")
+	}
+}
+
+func TestInitWithHandlerNotNilFail(t *testing.T) {
+	failureHandlerWithNotNil := func() (err interface{}) {
+		return "NotNilErr"
+	}
+	InitWithHandler(failureHandlerWithNotNil)
+	// TODO: Simular llamado al controlador "/"
+	if true {
+		t.Fatalf("TEST POR IMPLEMENTAR - InitWithHandler no retornó {Status: ERROR: ...} con retorno no nulo")
+	}
+}


### PR DESCRIPTION
- Se complementó el statusCheck con un nuevo check alternativo que acepta y llama a una función "handler" externa que se encarga del healthCheck
- Dicho handler puede incluso "romperse" y será capturado cuando se llame. Solo si el handler retorna `nil` se entenderá que todo va bien
- Es un cambio incremental, no "rompe" el funcionamiento de otros paquetes que actualmente usen `Init()`
- Se agregó un README para explicar el uso y ejemplos de uso

~~**NOTA:** Antes de fusionar, confirmar si esto es suficiente para que se considere fallido el statusCheck y/o si hay que ajustarlo~~
https://github.com/udistrital/utils_oas/blob/e87de53fc1058fe5afac581d7dda1ee231752ecd/apiStatusLib/apistatus.go#L18-L20

~~Lo anterior actualmente retornaría, por ejemplo, si el handler retornara "Base de datos caída":~~
```json
{
  "Status": "ERROR: Base de datos caída"
}
```
~~Una vez se confirme y/o ajuste, y para evitar hacer un nuevo PR; se podría quitar el estado Draft~~

De acuerdo a lo conversado con @fernandotower , basta con retornar un código HTTP distinto de 200 durante más de 3 ping para que se reinicie el servicio