### PR TITLE
Feature/interface converter

### DIFF
--- a/formatdata/FillStruct.go
+++ b/formatdata/FillStruct.go
@@ -1,0 +1,34 @@
+package formatdata
+
+import (
+	"encoding/json"
+)
+
+// FillStruct attempts to fill an `interface{}` with another `interface{}`
+//
+// Example Usage
+//   type User struct {
+//     Id   int
+//     Name string
+//   }
+//   userStruct := User{2, "Pepe"}
+//
+//   var userMap map[string]interface{}
+//   if err := formatdata.FillStruct(userStruct, &userMap); err != nil {
+//     panic(err)
+//   }
+//   logs.Info("struct --> map OK", userMap)
+//
+//   var userStruct2 User
+//   if err := formatdata.FillStruct(userMap, &userStruct2); err != nil {
+//     panic(err)
+//   }
+//   logs.Info("map --> struct OK", userStruct2)
+func FillStruct(in interface{}, out interface{}) (err error) {
+	var str []byte
+	if str, err = json.Marshal(in); err != nil {
+		return
+	}
+	err = json.Unmarshal(str, &out)
+	return
+}

--- a/formatdata/json_tools.go
+++ b/formatdata/json_tools.go
@@ -25,12 +25,6 @@ func FillStructV(m interface{}, s interface{}) (err error) {
 	return
 }
 
-func FillStruct(m interface{}, s interface{}) error {
-	j, _ := json.Marshal(m)
-	err := json.Unmarshal(j, s)
-	return err
-}
-
 func FillStructP(m interface{}, s interface{}) {
 	j, _ := json.Marshal(m)
 	err := json.Unmarshal(j, s)

--- a/formatdata/json_tools.go
+++ b/formatdata/json_tools.go
@@ -15,8 +15,7 @@ var validate *validator.Validate
 
 func FillStructV(m interface{}, s interface{}) (err error) {
 	validate = validator.New()
-	j, _ := json.Marshal(m)
-	err = json.Unmarshal(j, s)
+	err = FillStruct(m, &s)
 	valErr := validate.Struct(s)
 
 	if valErr != nil {
@@ -26,9 +25,7 @@ func FillStructV(m interface{}, s interface{}) (err error) {
 }
 
 func FillStructP(m interface{}, s interface{}) {
-	j, _ := json.Marshal(m)
-	err := json.Unmarshal(j, s)
-	if err != nil {
+	if err := FillStruct(m, &s); err != nil {
 		panic(err.Error())
 	}
 }
@@ -105,8 +102,7 @@ func FillStructDeep(m map[string]interface{}, fields string, s interface{}) (err
 			//fmt.Println(aux[value])
 		}
 	}
-	j, _ := json.Marshal(load)
-	err = json.Unmarshal(j, s)
+	err = FillStruct(load, &s)
 	return
 }
 


### PR DESCRIPTION
- `FillStruct` no llenaba adecuadamente los datos por falta de un `&`, arreglado
- `FillStruct` en el mismo `formatdata` pero movido a un archivo aparte y con documentacion
- `formatdata` refactorizado un poquito para usar `FillStruct`